### PR TITLE
Changing svkul name to kuk in sigla mapping

### DIFF
--- a/src/assets/i18n/cs.json
+++ b/src/assets/i18n/cs.json
@@ -901,7 +901,7 @@
     "CBA001": "Jihočeská vědecká knihovna v Českých Budějovicích",
     "OLA001": "Vědecká knihovna v Olomouci",
     "HKA001": "Studijní a vědecká knihovna v Hradci Králové",
-    "ULG001": "Severočeská vědecká knihovna v Ústí nad Labem",
+    "ULG001": "Knihovna Ústeckého kraje",
     "ABA007": "Knihovna AV ČR",
     "KVG001": "Krajská knihovna Karlovy Vary",
     "ABA013": "Národní technická knihovna",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -898,7 +898,7 @@
       "CBA001": "Jihočeská vědecká knihovna v Českých Budějovicích",
       "OLA001": "Vědecká knihovna v Olomouci",
       "HKA001": "Studijní a vědecká knihovna v Hradci Králové",
-      "ULG001": "Severočeská vědecká knihovna v Ústí nad Labem",
+      "ULG001": "Ústí Regional Library",
       "ABA007": "Knihovna AV ČR",
       "KVG001": "Krajská knihovna Karlovy Vary",
       "ABA013": "Národní technická knihovna",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -901,7 +901,7 @@
     "CBA001": "Research Library of South Bohemia in Ceske Budejovice",
     "OLA001": "Research Library in Olomouc",
     "HKA001": "Research Library in Hradec Králové",
-    "ULG001": "The North Bohemian Research Library in Ústí nad Labem",
+    "ULG001": "Ústí Regional Library",
     "ABA007": "Library of the ASCR",
     "KVG001": "Regional Library Karlovy Vary",
     "ABA013": "National Library of Technology",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -903,7 +903,7 @@
     "CBA001": "Research Library of South Bohemia in Ceske Budejovice",
     "OLA001": "Research Library in Olomouc",
     "HKA001": "Research Library in Hradec Králové",
-    "ULG001": "The North Bohemian Research Library in Ústí nad Labem",
+    "ULG001": "Ústí Regional Library",
     "ABA007": "Library of the ASCR",
     "KVG001": "Regional Library Karlovy Vary",
     "ABA013": "National Library of Technology",

--- a/src/assets/i18n/sk.json
+++ b/src/assets/i18n/sk.json
@@ -898,7 +898,7 @@
       "CBA001": "Jihočeská vědecká knihovna v Českých Budějovicích",
       "OLA001": "Vědecká knihovna v Olomouci",
       "HKA001": "Studijní a vědecká knihovna v Hradci Králové",
-      "ULG001": "Severočeská vědecká knihovna v Ústí nad Labem",
+      "ULG001": "Knihovna Ústeckého kraje",
       "ABA007": "Knihovna AV ČR",
       "KVG001": "Krajská knihovna Karlovy Vary",
       "ABA013": "Národní technická knihovna",

--- a/src/assets/i18n/sl.json
+++ b/src/assets/i18n/sl.json
@@ -889,7 +889,7 @@
       "CBA001": "Jihočeská vědecká knihovna v Českých Budějovicích",
       "OLA001": "Vědecká knihovna v Olomouci",
       "HKA001": "Studijní a vědecká knihovna v Hradci Králové",
-      "ULG001": "Severočeská vědecká knihovna v Ústí nad Labem",
+      "ULG001": "Knihovna Ústeckého kraje",
       "ABA007": "Knihovna AV ČR",
       "KVG001": "Krajská knihovna Karlovy Vary",
       "ABA013": "Národní technická knihovna",

--- a/src/assets/i18n/xx.json
+++ b/src/assets/i18n/xx.json
@@ -901,7 +901,7 @@
     "CBA001": "Research Library of South Bohemia in Ceske Budejovice",
     "OLA001": "Research Library in Olomouc",
     "HKA001": "Research Library in Hradec Králové",
-    "ULG001": "The North Bohemian Research Library in Ústí nad Labem",
+    "ULG001": "Ústí Regional Library",
     "ABA007": "Library of the ASCR",
     "KVG001": "Regional Library Karlovy Vary",
     "ABA013": "National Library of Technology",


### PR DESCRIPTION
V mapovaní sigly na názov knižnice ostal názov svkul nezmenený (na ostatných miestach v klientovi je už nový názov) . Mením na kuk po výzve od kolegov z tejto knižnice.

Róbert Randiak, MZK