### PR TITLE
Oprava resolvingu perzistentních odkazů pro supplement a jeho potomky; refactoring komponenty

### DIFF
--- a/src/app/persistent-link/persistent-link.component.ts
+++ b/src/app/persistent-link/persistent-link.component.ts
@@ -1,88 +1,176 @@
-import { HistoryService } from './../services/history.service';
-import { DocumentItem } from './../model/document_item.model';
-import { KrameriusApiService } from './../services/kramerius-api.service';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { Component, OnInit } from '@angular/core';
-import { NotFoundError } from '../common/errors/not-found-error';
+import { Subject, combineLatest } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+
 import { AppSettings } from '../services/app-settings';
-import { combineLatest } from 'rxjs';
+import { HistoryService } from '../services/history.service';
+import { KrameriusApiService } from '../services/kramerius-api.service';
+import { DocumentItem } from '../model/document_item.model';
+import { NotFoundError } from '../common/errors/not-found-error';
+
+type ContextItem = DocumentItem['context'][number];
 
 @Component({
   selector: 'app-persistent-link',
   templateUrl: './persistent-link.component.html'
 })
-export class PersistentLinkComponent implements OnInit {
+export class PersistentLinkComponent implements OnInit, OnDestroy {
+  private destroy$ = new Subject<void>();
 
-  constructor(private route: ActivatedRoute,
+  constructor(
+    private route: ActivatedRoute,
     private router: Router,
     private appSettings: AppSettings,
     private history: HistoryService,
-    private api: KrameriusApiService) { }
+    private api: KrameriusApiService
+  ) {}
 
-  ngOnInit() {  
-    combineLatest([this.route.paramMap, this.route.queryParams]).subscribe(results => {
-      const params = results[0];
-      const queryParams = results[1];
-      const fulltext = queryParams['fulltext'];
-      const bb = queryParams['bb'];
-      const uuid = params.get('uuid');
-      this.api.getItem(uuid).subscribe(
-        (item: DocumentItem) => {
-          this.resolveLink(item, fulltext, bb);
-        },
-        error => {
-          if (error instanceof NotFoundError) {
-              this.router.navigateByUrl(this.appSettings.getRouteFor('404'), { skipLocationChange: true });
-          }
+  ngOnInit(): void {
+    combineLatest([this.route.paramMap, this.route.queryParams])
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(([params, queryParams]) => {
+        const uuid = params.get('uuid');
+        if (!uuid) {
+          this.navigateTo404();
+          return;
+        }
+
+        this.api.getItem(uuid)
+          .pipe(takeUntil(this.destroy$))
+          .subscribe({
+            next: (item) => this.resolveLink(item, queryParams['fulltext'], queryParams['bb']),
+            error: (error) => {
+              if (error instanceof NotFoundError) {
+                this.navigateTo404();
+              }
+            }
+          });
       });
-    });
   }
 
-  private resolveLink(item: DocumentItem, fulltext?: string, bb?: string) {
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  private navigateTo404(): void {
+    this.router.navigateByUrl(this.appSettings.getRouteFor('404'), { skipLocationChange: true });
+  }
+
+  private getParentContext(item: DocumentItem, offset = 2): ContextItem | undefined {
+    return item.context?.[item.context.length - offset];
+  }
+
+  private resolveParentForPage(item: DocumentItem): ContextItem | undefined {
+    let parent = this.getParentContext(item);
+    if (parent?.doctype === 'supplement') {
+      const grandparent = this.getParentContext(item, 3);
+      // Pro page: přeskočit supplement, ALE ne pokud by to vedlo na periodicalvolume (příloha ročníku)
+      if (grandparent?.uuid && grandparent.doctype !== 'periodicalvolume') {
+        parent = grandparent;
+      }
+    }
+    return parent;
+  }
+
+  private resolveParentForArticle(item: DocumentItem): ContextItem | undefined {
+    let parent = this.getParentContext(item);
+    if (parent?.doctype === 'supplement') {
+      const grandparent = this.getParentContext(item, 3);
+      // Pro article: přeskočit supplement vždy
+      if (grandparent?.uuid) {
+        parent = grandparent;
+      }
+    }
+    return parent;
+  }
+
+  private resolveLink(item: DocumentItem, fulltext?: string, bb?: string): void {
     this.history.removeCurrent();
-    if (item.doctype === 'page') {
-      const parentUuid = item.context[item.context.length - 2].uuid;
-      this.router.navigate(['/view', parentUuid], { queryParams: { page: item.uuid, fulltext: fulltext, bb: bb } });
-    } else if (item.doctype === 'article') {
-      const parentUuid = item.context[item.context.length - 2].uuid;
-      this.router.navigate(['/view', parentUuid], { queryParams: { article: item.uuid } });
-    } else if (item.doctype === 'periodical' || item.doctype === 'periodicalvolume' || item.doctype === 'convolute') {
-      this.router.navigate(['/periodical', item.uuid], { queryParams: { fulltext: fulltext } });
-    } else if (item.doctype === 'soundrecording') {
-      this.router.navigate(['/music', item.uuid]);
-    } else if (item.doctype === 'soundunit') {
-      const soundrecording = item.context.find(item => item.doctype == 'soundrecording');
-      if (soundrecording && soundrecording.uuid) {
-        this.router.navigate(['/music', soundrecording.uuid]);
-      } else {
-        this.router.navigateByUrl(this.appSettings.getRouteFor('404'), { skipLocationChange: true });
+
+    switch (item.doctype) {
+      case 'page': {
+        const parent = this.resolveParentForPage(item);
+        if (parent?.uuid) {
+          this.router.navigate(['/view', parent.uuid], { queryParams: { page: item.uuid, fulltext, bb } });
+        } else {
+          this.navigateTo404();
+        }
+        break;
       }
-    } else if (item.doctype === 'track') {
-      const soundrecording = item.context.find(item => item.doctype == 'soundrecording');
-      if (soundrecording && soundrecording.uuid) {
-        this.router.navigate(['/music', soundrecording.uuid], { replaceUrl: true, queryParams: { 'track': item.uuid } });
-      } else {
-        this.router.navigateByUrl(this.appSettings.getRouteFor('404'), { skipLocationChange: true });
+
+      case 'article': {
+        const parent = this.resolveParentForArticle(item);
+        if (parent?.uuid) {
+          this.router.navigate(['/view', parent.uuid], { queryParams: { article: item.uuid } });
+        } else {
+          this.navigateTo404();
+        }
+        break;
       }
-    } else if (item.doctype === 'supplement') {
-      const periodicalItem = item.context.find(item => item.doctype == 'periodicalitem');
-      if (periodicalItem && periodicalItem.uuid) {
-        this.api.getChildren(item.uuid).subscribe((items) => {
-          if (items && items.length > 0) {
-            this.router.navigate(['/view', periodicalItem.uuid], { queryParams: { page: items[0].pid } });
-          } else {
-            this.router.navigate(['/view', periodicalItem.uuid]);
-          }
-        });
-        this.router.navigate(['/view', periodicalItem.uuid]);
-      } else {
-        this.router.navigate(['/view', item.uuid]);
-      }
-    } else if (item.doctype === 'collection') {
-      this.router.navigate(['/collection', item.uuid]);
-    } else {
-      this.router.navigate(['/view', item.uuid], { queryParams: { fulltext: fulltext } });
+
+      case 'periodical':
+      case 'periodicalvolume':
+      case 'convolute':
+        this.router.navigate(['/periodical', item.uuid], { queryParams: { fulltext } });
+        break;
+
+      case 'soundrecording':
+        this.router.navigate(['/music', item.uuid]);
+        break;
+
+      case 'soundunit':
+      case 'track':
+        this.handleSoundNavigation(item);
+        break;
+
+      case 'supplement':
+        this.handleSupplementNavigation(item);
+        break;
+
+      case 'collection':
+        this.router.navigate(['/collection', item.uuid]);
+        break;
+
+      default:
+        this.router.navigate(['/view', item.uuid], { queryParams: { fulltext } });
     }
   }
 
+  private handleSoundNavigation(item: DocumentItem): void {
+    const soundrecording = item.context?.find(ctx => ctx.doctype === 'soundrecording');
+    if (soundrecording?.uuid) {
+      const queryParams = item.doctype === 'track' ? { track: item.uuid } : undefined;
+      this.router.navigate(['/music', soundrecording.uuid], { queryParams });
+    } else {
+      this.navigateTo404();
+    }
+  }
+
+  private handleSupplementNavigation(item: DocumentItem): void {
+    const parent = this.getParentContext(item);
+
+    if (parent?.doctype === 'periodicalvolume') {
+      this.router.navigate(['/view', item.uuid]);
+      return;
+    }
+
+    if (!parent?.uuid) {
+      this.router.navigate(['/view', item.uuid]);
+      return;
+    }
+
+    this.api.getChildren(item.uuid)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (children) => {
+          const queryParams = children?.[0]?.pid ? { page: children[0].pid } : undefined;
+          this.router.navigate(['/view', parent.uuid], { queryParams });
+        },
+        error: () => {
+          this.router.navigate(['/view', parent.uuid]);
+        }
+      });
+  }
 }

--- a/src/app/persistent-link/persistent-link.component.ts
+++ b/src/app/persistent-link/persistent-link.component.ts
@@ -141,8 +141,14 @@ export class PersistentLinkComponent implements OnInit, OnDestroy {
   private handleSoundNavigation(item: DocumentItem): void {
     const soundrecording = item.context?.find(ctx => ctx.doctype === 'soundrecording');
     if (soundrecording?.uuid) {
-      const queryParams = item.doctype === 'track' ? { track: item.uuid } : undefined;
-      this.router.navigate(['/music', soundrecording.uuid], { queryParams });
+      if (item.doctype === 'track') {
+        this.router.navigate(['/music', soundrecording.uuid], {
+          replaceUrl: true,
+          queryParams: { track: item.uuid }
+        });
+      } else {
+        this.router.navigate(['/music', soundrecording.uuid]);
+      }
     } else {
       this.navigateTo404();
     }


### PR DESCRIPTION
Closes #856

## Popis změn

### Opravy

- `page` a `article` v kontextu `supplement` nyní správně navigují na `periodicalitem` nebo `monograph` místo na samotný `supplement`
- Přidána podpora pro `monograph/supplement` (dříve nefunkční fallback)
- Zachováno samostatné zobrazení pro `periodicalvolume/supplement` (příloha ročníku)

### Refaktoring

- Oprava memory leak – přidán `takeUntil(destroy$)` a `ngOnDestroy()`
- Null safety pomocí optional chaining (`parent?.uuid`)
- Extrakce helper metod `resolveParentForPage()` a `resolveParentForArticle()`
- Error handling pro `getChildren()`
- Nahrazení if-else řetězce switchem